### PR TITLE
Fix for a typo, which causes retrieval of backup schedules to fail

### DIFF
--- a/library/ZendService/Rackspace/Servers.php
+++ b/library/ZendService/Rackspace/Servers.php
@@ -984,8 +984,8 @@ class Servers extends AbstractRackspace
             case '200' :
             case '203' : // break intentionally omitted
                 $backup = json_decode($result->getBody(),true);
-                if (isset($image['backupSchedule'])) {
-                    return $image['backupSchedule'];
+                if (isset($backup['backupSchedule'])) {
+                    return $backup['backupSchedule'];
                 }
                 break;
             case '503' :


### PR DESCRIPTION
The same typo in ZF1: http://framework.zend.com/issues/browse/ZF-12378
