### PR TITLE
Fixes for getCdnTtl(), getCdnUri() and getCdnUriSsl() always returning false

### DIFF
--- a/library/ZendService/Rackspace/Files/Container.php
+++ b/library/ZendService/Rackspace/Files/Container.php
@@ -97,7 +97,7 @@ class Container
     public function getCdnTtl()
     {
         $data = $this->getCdnInfo();
-        if (!isset($data['ttl'])) {
+        if (isset($data['ttl'])) {
             return $data['ttl'];
         }
         return false;
@@ -110,7 +110,7 @@ class Container
     public function isCdnLogEnabled()
     {
         $data = $this->getCdnInfo();
-        if (!isset($data['log_retention'])) {
+        if (isset($data['log_retention'])) {
             return $data['log_retention'];
         }
         return false;
@@ -123,7 +123,7 @@ class Container
     public function getCdnUri()
     {
         $data = $this->getCdnInfo();
-        if (!isset($data['cdn_uri'])) {
+        if (isset($data['cdn_uri'])) {
             return $data['cdn_uri'];
         }
         return false;
@@ -136,7 +136,7 @@ class Container
     public function getCdnUriSsl()
     {
         $data = $this->getCdnInfo();
-        if (!isset($data['cdn_uri_ssl'])) {
+        if (isset($data['cdn_uri_ssl'])) {
             return $data['cdn_uri_ssl'];
         }
         return false;

--- a/tests/ZendService/Rackspace/Files/OfflineTest.php
+++ b/tests/ZendService/Rackspace/Files/OfflineTest.php
@@ -12,6 +12,7 @@ namespace ZendServiceTest\Rackspace\Files;
 
 use ZendService\Rackspace\Files as RackspaceFiles;
 use ZendService\Rackspace\Files\ContainerList;
+use ZendService\Rackspace\Files\Container as RackspaceContainer;
 use Zend\Http\Client\Adapter\Test as HttpTest;
 
 /**
@@ -49,6 +50,12 @@ class OfflineTest extends \PHPUnit_Framework_TestCase
      */
     protected $metadata2;
     /**
+     * Reference to Container
+     *
+     * @var ZendService\Rackspace\Files\Container
+     */
+    protected $container;
+    /**
      * Set up the test case
      *
      * @return void
@@ -56,6 +63,7 @@ class OfflineTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->rackspace = new RackspaceFiles('foo','bar');
+        $this->container = new RackspaceContainer($this->rackspace, array('name' => TESTS_ZEND_SERVICE_RACKSPACE_CONTAINER_NAME));
 
         $this->httpClientAdapterTest = new HttpTest();
 
@@ -234,6 +242,36 @@ class OfflineTest extends \PHPUnit_Framework_TestCase
     {
         $data= $this->rackspace->updateCdnContainer(TESTS_ZEND_SERVICE_RACKSPACE_CONTAINER_NAME,null,false);
         $this->assertTrue($data!==false);
+    }
+
+    public function testGetInfoCdnContainer()
+    {
+        $info = $this->rackspace->getInfoCdnContainer(TESTS_ZEND_SERVICE_RACKSPACE_CONTAINER_NAME);
+        $this->assertTrue($info!==false);
+        $this->assertTrue(is_array($info));
+        $this->assertTrue(!empty($info['ttl']));
+        $this->assertTrue(!empty($info['cdn_uri']));
+        $this->assertTrue(!empty($info['cdn_uri_ssl']));
+        $this->assertTrue($info['cdn_enabled']===true);
+        $this->assertTrue($info['log_retention']===true);
+    }
+
+    public function testGetCdnTtl()
+    {
+        $ttl = $this->container->getCdnTtl();
+        $this->assertTrue($ttl!==false);
+    }
+
+    public function testGetCdnUri()
+    {
+        $uri = $this->container->getCdnUri();
+        $this->assertTrue($uri!==false);
+    }
+
+    public function testGetCdnUriSsl()
+    {
+        $uri = $this->container->getCdnUriSsl();
+        $this->assertTrue($uri!==false);
     }
 
 

--- a/tests/ZendService/Rackspace/Files/_files/testGetCdnTtl.response
+++ b/tests/ZendService/Rackspace/Files/_files/testGetCdnTtl.response
@@ -1,0 +1,13 @@
+HTTP/1.1 204 No Content
+Content-Type: text/html; charset=UTF-8
+X-Log-Retention: False
+Date: Fri, 15 Mar 2013 12:40:32 GMT
+X-Cdn-Uri: http://c754396.r96.cf2.rackcdn.com
+X-Cdn-Ssl-Uri: https://c754396.r96.cf2.rackcdn.com
+X-Cdn-Enabled: True
+X-Cdn-Ios-Uri: http://c754396.r96.cf2.rackcdn.com
+X-Trans-Id: tx6f66c89e78fd4a31b7507bf259c5a79c
+Connection: close
+X-Ttl: 259200
+X-Cdn-Streaming-Uri: http://c754396.r96.cf2.rackcdn.com
+Content-Length: 0

--- a/tests/ZendService/Rackspace/Files/_files/testGetCdnUri.response
+++ b/tests/ZendService/Rackspace/Files/_files/testGetCdnUri.response
@@ -1,0 +1,13 @@
+HTTP/1.1 204 No Content
+Content-Type: text/html; charset=UTF-8
+X-Log-Retention: False
+Date: Fri, 15 Mar 2013 12:40:32 GMT
+X-Cdn-Uri: http://c754396.r96.cf2.rackcdn.com
+X-Cdn-Ssl-Uri: https://c754396.r96.cf2.rackcdn.com
+X-Cdn-Enabled: True
+X-Cdn-Ios-Uri: http://c754396.r96.cf2.rackcdn.com
+X-Trans-Id: tx6f66c89e78fd4a31b7507bf259c5a79c
+Connection: close
+X-Ttl: 259200
+X-Cdn-Streaming-Uri: http://c754396.r96.cf2.rackcdn.com
+Content-Length: 0

--- a/tests/ZendService/Rackspace/Files/_files/testGetCdnUriSSl.response
+++ b/tests/ZendService/Rackspace/Files/_files/testGetCdnUriSSl.response
@@ -1,0 +1,13 @@
+HTTP/1.1 204 No Content
+Content-Type: text/html; charset=UTF-8
+X-Log-Retention: False
+Date: Fri, 15 Mar 2013 12:40:32 GMT
+X-Cdn-Uri: http://c754396.r96.cf2.rackcdn.com
+X-Cdn-Ssl-Uri: https://c754396.r96.cf2.rackcdn.com
+X-Cdn-Enabled: True
+X-Cdn-Ios-Uri: http://c754396.r96.cf2.rackcdn.com
+X-Trans-Id: tx6f66c89e78fd4a31b7507bf259c5a79c
+Connection: close
+X-Ttl: 259200
+X-Cdn-Streaming-Uri: http://c754396.r96.cf2.rackcdn.com
+Content-Length: 0

--- a/tests/ZendService/Rackspace/Files/_files/testGetInfoCdnContainer.response
+++ b/tests/ZendService/Rackspace/Files/_files/testGetInfoCdnContainer.response
@@ -1,0 +1,13 @@
+HTTP/1.1 204 No Content
+Content-Type: text/html; charset=UTF-8
+X-Log-Retention: True
+Date: Fri, 15 Mar 2013 12:40:32 GMT
+X-Cdn-Uri: http://c754396.r96.cf2.rackcdn.com
+X-Cdn-Ssl-Uri: https://c754396.r96.cf2.rackcdn.com
+X-Cdn-Enabled: True
+X-Cdn-Ios-Uri: http://c754396.r96.cf2.rackcdn.com
+X-Trans-Id: tx6f66c89e78fd4a31b7507bf259c5a79c
+Connection: close
+X-Ttl: 259200
+X-Cdn-Streaming-Uri: http://c754396.r96.cf2.rackcdn.com
+Content-Length: 0


### PR DESCRIPTION
Not 100% sure about the test cases - they work offline, but haven't checked what's supposed to happen in online mode.
