### PR TITLE
Fixed copyObject() sending Content-Type: application/x-www-form-urlencod...

### DIFF
--- a/library/ZendService/Rackspace/AbstractRackspace.php
+++ b/library/ZendService/Rackspace/AbstractRackspace.php
@@ -328,6 +328,9 @@ abstract class AbstractRackspace
         if (empty($headers[self::AUTHUSER_HEADER])) {
             $headers[self::AUTHTOKEN]= $this->getToken();
         }
+        if (empty($headers['Content-Type']) && $method == 'PUT' && empty($body)) {
+            $headers['Content-Type'] = '';
+        }
         $client->setMethod($method);
         if (empty($data['format'])) {
             $data['format']= self::API_FORMAT;

--- a/tests/ZendService/Rackspace/Files/OfflineTest.php
+++ b/tests/ZendService/Rackspace/Files/OfflineTest.php
@@ -174,6 +174,7 @@ class OfflineTest extends \PHPUnit_Framework_TestCase
                                               TESTS_ZEND_SERVICE_RACKSPACE_CONTAINER_NAME,
                                               TESTS_ZEND_SERVICE_RACKSPACE_OBJECT_NAME.'-copy');
         $this->assertTrue($result);
+        $this->assertNotContains('application/x-www-form-urlencoded', $this->rackspace->getHttpClient()->getLastRawRequest());
     }
 
     public function testGetObjects()


### PR DESCRIPTION
If you try to copy an object from one cloud files location to another it sets the Content-Type header to 'application/x-www-form-urlencoded'. It should preserve the content type.

This is a port from the ZF1 issue here:
http://framework.zend.com/issues/browse/ZF-12549
